### PR TITLE
Used `$` instead of `&&` to chain a command 

### DIFF
--- a/dekoder-cso-builder/Dockerfile
+++ b/dekoder-cso-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-RUN apt update && apt -y install gosu time git gridsite-clients curl zip unzip default-jdk locales && apt clean
+RUN apt update && apt -y install gosu time git gridsite-clients curl zip unzip openjdk-19-jdk locales && apt clean
 
 # Add CodeSonar from the latest CodeSonar release
 COPY --from=codesecurese/codesonar-3-builder:8.1b0 /opt/codesonar/. /opt/codesonar
@@ -13,15 +13,15 @@ RUN export LC_ALL=en_US.UTF-8
 RUN export LANG=en_US.UTF-8
 RUN locale-gen en_US.UTF-8
 
-# To install kotlin
-RUN curl -s "https://get.sdkman.io" | /bin/bash
-
-# this SHELL command is needed to allow using source
-SHELL ["/bin/bash", "-c"]  
-RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install kotlin
-
 RUN groupadd --gid 1000 user\
     && useradd --uid 1000 --gid 1000 -m user
 
 USER user
 
+# To install kotlin
+RUN curl -s "https://get.sdkman.io" | /bin/bash
+
+# this SHELL command is needed to allow using source
+SHELL ["/bin/bash", "-c"]  
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" 
+RUN sdk install kotlin

--- a/dekoder-cso-builder/Dockerfile
+++ b/dekoder-cso-builder/Dockerfile
@@ -2,12 +2,6 @@ FROM ubuntu:22.04
 
 RUN apt update && apt -y install gosu time git gridsite-clients curl wget zip unzip default-jdk kotlin locales && apt clean
 
-# To install Gradle
-SHELL ["/bin/bash", "-c"]  
-RUN cd /opt && wget https://services.gradle.org/distributions/gradle-8.6-bin.zip && unzip gradle-8.6-bin.zip && mv gradle-8.6 gradle
-ENV GRADLE_HOME=/opt/gradle
-ENV PATH=$PATH:$GRADLE_HOME/bin 
-
 # Add CodeSonar from the latest CodeSonar release
 COPY --from=codesecurese/codesonar-3-builder:8.1b0 /opt/codesonar/. /opt/codesonar
 COPY --from=codesecurese/codesonar-3-builder:8.1b0 opt/codesonar-github/. /opt/codesonar-github
@@ -24,9 +18,3 @@ RUN groupadd --gid 1000 user\
 
 USER user
 
-
-
-# this SHELL command is needed to allow using source
-#SHELL ["/bin/bash", "-c"]  
-#RUN source "$HOME/.sdkman/bin/sdkman-init.sh" 
-#RUN sdk install kotlin

--- a/dekoder-cso-builder/Dockerfile
+++ b/dekoder-cso-builder/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -s "https://get.sdkman.io" | /bin/bash
 
 # this SHELL command is needed to allow using source
 SHELL ["/bin/bash", "-c"]  
-RUN source "$HOME/.sdkman/bin/sdkman-init.sh" $$ sdk install kotlin
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install kotlin
 
 RUN groupadd --gid 1000 user\
     && useradd --uid 1000 --gid 1000 -m user

--- a/dekoder-cso-builder/Dockerfile
+++ b/dekoder-cso-builder/Dockerfile
@@ -1,6 +1,12 @@
 FROM ubuntu:22.04
 
-RUN apt update && apt -y install gosu time git gridsite-clients curl zip unzip openjdk-19-jdk locales && apt clean
+RUN apt update && apt -y install gosu time git gridsite-clients curl wget zip unzip default-jdk kotlin locales && apt clean
+
+# To install Gradle
+SHELL ["/bin/bash", "-c"]  
+RUN cd /opt && wget https://services.gradle.org/distributions/gradle-8.6-bin.zip && unzip gradle-8.6-bin.zip && mv gradle-8.6 gradle
+ENV GRADLE_HOME=/opt/gradle
+ENV PATH=$PATH:$GRADLE_HOME/bin 
 
 # Add CodeSonar from the latest CodeSonar release
 COPY --from=codesecurese/codesonar-3-builder:8.1b0 /opt/codesonar/. /opt/codesonar
@@ -18,10 +24,9 @@ RUN groupadd --gid 1000 user\
 
 USER user
 
-# To install kotlin
-RUN curl -s "https://get.sdkman.io" | /bin/bash
+
 
 # this SHELL command is needed to allow using source
-SHELL ["/bin/bash", "-c"]  
-RUN source "$HOME/.sdkman/bin/sdkman-init.sh" 
-RUN sdk install kotlin
+#SHELL ["/bin/bash", "-c"]  
+#RUN source "$HOME/.sdkman/bin/sdkman-init.sh" 
+#RUN sdk install kotlin


### PR DESCRIPTION
The install command that dropped Kotlin-c on the image was malformed.